### PR TITLE
Fix German STR_TBUG_SET_FUNC_AUTOCOMPLETE translation

### DIFF
--- a/Stringtable.xml
+++ b/Stringtable.xml
@@ -1079,7 +1079,7 @@
         <English>Function Auto-completion</English>
         <Czech>Function Auto-completion</Czech>
         <French>Function Auto-completion</French>
-        <German>Auto-Vervollständigungs-Funktion</German>
+        <German>Automatische Funktionsvervollständigung</German>
         <Italian>Function Auto-completion</Italian>
         <Polish>Function Auto-completion</Polish>
         <Portuguese>Function Auto-completion</Portuguese>


### PR DESCRIPTION
Sorry for the late reply but indeed my translation wasn't the best.
Just to confirm:
This is a setting to enable/disable the auto-completion of functions, right?
If so my proposed change now is correct.